### PR TITLE
Kroki service management

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -15,7 +15,8 @@ Diagram
 
 ```@autodocs
 Modules = [ Kroki.Service ]
-Order = [ :module, :function ]
+Order = [ :module, :type, :function ]
+Filter = name -> "$name" !== "executeDockerCompose"
 ```
 
 ### Shorthands
@@ -47,4 +48,8 @@ Modules = [ Kroki.Documentation ]
 ```@autodocs
 Modules = [ Kroki.Service ]
 Order = [ :constant ]
+```
+
+```@docs
+Kroki.Service.executeDockerCompose
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -11,6 +11,13 @@ Kroki
 Diagram
 ```
 
+### Service Management
+
+```@autodocs
+Modules = [ Kroki.Service ]
+Order = [ :module, :function ]
+```
+
 ### Shorthands
 
 ```@autodocs
@@ -33,4 +40,11 @@ render
 
 ```@autodocs
 Modules = [ Kroki.Documentation ]
+```
+
+### Service Management
+
+```@autodocs
+Modules = [ Kroki.Service ]
+Order = [ :constant ]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,7 +27,10 @@ Kroki provides support for a wide array of diagramming languages such as
 [many more](https://kroki.io/#support). The package can be configured to use
 the publicly hosted server at [https://kroki.io](https://kroki.io) or
 [self-hosted instances](https://docs.kroki.io/kroki/setup/install/) (see
-[`render`](@ref) for configuration instructions).
+[`render`](@ref) for configuration instructions). A basic configuration file
+(`docker-services.yml`) for [Docker Compose](https://docs.docker.com/compose/)
+is available in the `support` folder of the package for those interested in
+self-hosting the service.
 
 The aim of the package is to make it easy to integrate descriptive diagrams
 within code and docstrings (rendered as text), while upgrading the diagrams to

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,10 +27,10 @@ Kroki provides support for a wide array of diagramming languages such as
 [many more](https://kroki.io/#support). The package can be configured to use
 the publicly hosted server at [https://kroki.io](https://kroki.io) or
 [self-hosted instances](https://docs.kroki.io/kroki/setup/install/) (see
-[`render`](@ref) for configuration instructions). A basic configuration file
-(`docker-services.yml`) for [Docker Compose](https://docs.docker.com/compose/)
-is available in the `support` folder of the package for those interested in
-self-hosting the service.
+[`setEndpoint!`](@ref Kroki.Service.setEndpoint!) for configuration
+instructions). A basic configuration file (`docker-services.yml`) for [Docker
+Compose](https://docs.docker.com/compose/) is available in the `support` folder
+of the package for those interested in self-hosting the service.
 
 The aim of the package is to make it easy to integrate descriptive diagrams
 within code and docstrings (rendered as text), while upgrading the diagrams to

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -18,6 +18,9 @@ include("./kroki/documentation.jl")
 using .Documentation
 @setupDocstringMarkup()
 
+include("./kroki/service.jl")
+using .Service: ENDPOINT
+
 """
 A representation of a diagram that can be rendered by a Kroki service.
 
@@ -134,11 +137,6 @@ RenderError(::Diagram, exception::Exception) = exception
 Renders a [`Diagram`](@ref) through a Kroki service to the specified output
 format.
 
-A `KROKI_ENDPOINT` environment variable can be set, specifying the URI of a
-specific instance of Kroki to use (e.g. when using a [privately hosted
-instance](https://docs.kroki.io/kroki/setup/install/)). By default the
-[publicly hosted service](https://kroki.io) is used.
-
 If the Kroki service responds with an error throws an
 [`InvalidDiagramSpecificationError`](@ref) or
 [`InvalidOutputFormatError`](@ref) if a know type of error occurs. Other errors
@@ -152,7 +150,7 @@ render(diagram::Diagram, output_format::AbstractString) =
         "GET",
         join(
           [
-            get(ENV, "KROKI_ENDPOINT", "https://kroki.io"),
+            ENDPOINT[],
             lowercase("$(diagram.type)"),
             output_format,
             UriSafeBase64Payload(diagram),

--- a/src/kroki/service.jl
+++ b/src/kroki/service.jl
@@ -1,0 +1,48 @@
+"""
+Defines functions and constants managing the Kroki service the rest of the
+package uses to render diagrams. These services can be either local or remote.
+"""
+module Service
+
+using ..Documentation
+@setupDocstringMarkup()
+
+"""
+The default [`ENDPOINT`](@ref) to use, i.e. the [publicly hosted
+version](https://kroki.io).
+"""
+const DEFAULT_ENDPOINT = "https://kroki.io"
+
+"The currently active Kroki service endpoint being used."
+const ENDPOINT = Ref{String}("https://kroki.io")
+
+"""
+Sets the [`ENDPOINT`](@ref) using a fallback mechanism if no `endpoint` is
+provided.
+
+The fallback mechanism checks for a `KROKI_ENDPOINT` environment variable
+specifying an endpoint (e.g. to be used across Julia instances). If this
+environment variable is also not present the [`DEFAULT_ENDPOINT`](@ref) is
+used.
+
+This can, for instance, be used in cases where a [privately hosted
+instance](https://docs.kroki.io/kroki/setup/install/) is available.
+
+Returns the value that [`ENDPOINT`](@ref) got set to.
+
+# Examples
+
+- `setEndpoint!()`
+- `setEndpoint!("http://localhost:8000")`
+"""
+function setEndpoint!(
+  endpoint::AbstractString = get(ENV, "KROKI_ENDPOINT", DEFAULT_ENDPOINT)
+)
+  ENDPOINT[] != endpoint && @info "Setting Kroki service endpoint to $(endpoint)."
+  ENDPOINT[] = String(endpoint)
+end
+
+# Ensure `ENDPOINT` has a valid value
+__init__() = setEndpoint!()
+
+end

--- a/src/kroki/service.jl
+++ b/src/kroki/service.jl
@@ -129,6 +129,21 @@ function status()
   merge(services_by_state...)
 end
 
+"""
+Stops any running Kroki service components ensuring [`ENDPOINT`](@ref) no
+longer points to the stopped service.
+
+Cleans up left-over containers by default. This behavior can be turned off by
+passing `false` to the function.
+"""
+function stop!(perform_cleanup::Bool = true)
+  @info "Stopping Kroki service components."
+  EXECUTE_DOCKER_COMPOSE[]("stop")
+  perform_cleanup && EXECUTE_DOCKER_COMPOSE[](["rm", "--force"])
+  setEndpoint!()
+  return
+end
+
 "Updates the Docker images for the individual Kroki service components."
 function update!()
   EXECUTE_DOCKER_COMPOSE[](["pull", "--quiet"])

--- a/src/kroki/service.jl
+++ b/src/kroki/service.jl
@@ -129,6 +129,12 @@ function status()
   merge(services_by_state...)
 end
 
+"Updates the Docker images for the individual Kroki service components."
+function update!()
+  EXECUTE_DOCKER_COMPOSE[](["pull", "--quiet"])
+  return
+end
+
 # Ensure `ENDPOINT` has a valid value
 __init__() = setEndpoint!()
 

--- a/src/kroki/service.jl
+++ b/src/kroki/service.jl
@@ -24,7 +24,9 @@ of errors that may occur while trying to execute `docker-compose`.
 struct DockerComposeExecutionError <: Exception
   message::String
 end
-Base.showerror(io::IO, error::DockerComposeExecutionError) = print(io, """
+Base.showerror(io::IO, error::DockerComposeExecutionError) = print(
+  io,
+  """
 An error occurred while executing `docker-compose`.
 
 This may be caused by a change in its interface. If you believe this error to
@@ -35,15 +37,14 @@ including the error message below and a description of when the error occurred.
 The reported error was:
 
 $(error.message)
-""")
+""",
+)
 
 "The currently active Kroki service endpoint being used."
 const ENDPOINT = Ref{String}("https://kroki.io")
 
 "Path to the Docker Compose definitions for running a local Kroki service."
-const SERVICE_DEFINITION_FILE = realpath(
-  "$(@__DIR__)/../../support/docker-services.yml"
-)
+const SERVICE_DEFINITION_FILE = realpath("$(@__DIR__)/../../support/docker-services.yml")
 
 """
 Helper function for executing Docker Compose commands.
@@ -62,12 +63,11 @@ function executeDockerCompose(cmd::Vector{String})
     run(pipeline(
       `docker-compose --file $(SERVICE_DEFINITION_FILE) --project-name krokijl $cmd`;
       stderr = captured_stderr,
-      stdout = captured_stdout
+      stdout = captured_stdout,
     ))
   catch exception
-    exception isa Base.IOError && throw(ErrorException(
-      "Missing dependencies! Docker and/or Docker Compose do not appear to be available"
-    ))
+    exception isa Base.IOError &&
+    throw(ErrorException("Missing dependencies! Docker and/or Docker Compose do not appear to be available"))
 
     throw(DockerComposeExecutionError(String(take!(captured_stderr))))
   end
@@ -100,7 +100,7 @@ Returns the value that [`ENDPOINT`](@ref) got set to.
 - `setEndpoint!("http://localhost:8000")`
 """
 function setEndpoint!(
-  endpoint::AbstractString = get(ENV, "KROKI_ENDPOINT", DEFAULT_ENDPOINT)
+  endpoint::AbstractString = get(ENV, "KROKI_ENDPOINT", DEFAULT_ENDPOINT),
 )
   ENDPOINT[] != endpoint && @info "Setting Kroki service endpoint to $(endpoint)."
   ENDPOINT[] = String(endpoint)
@@ -131,18 +131,15 @@ julia> status()
 ```
 """
 function status()
-  states_to_bool = Pair{String,Bool}["running" => true, "stopped" => false]
+  states_to_bool = Pair{String, Bool}["running" => true, "stopped" => false]
 
-  services_by_state = map(states_to_bool) do (state, running)::Pair{String,Bool}
-    services_with_state = EXECUTE_DOCKER_COMPOSE[](
-      ["ps", "--filter", "status=$state", "--services"]
-    )
+  services_by_state = map(states_to_bool) do (state, running)::Pair{String, Bool}
+    services_with_state =
+      EXECUTE_DOCKER_COMPOSE[](["ps", "--filter", "status=$state", "--services"])
 
-    service_symbols = Symbol.(
-      split(services_with_state, '\n'; keepempty = false)
-    )
+    service_symbols = Symbol.(split(services_with_state, '\n'; keepempty = false))
 
-    (; zip(service_symbols, Iterators.repeated(running))... )
+    (; zip(service_symbols, Iterators.repeated(running))...)
   end
 
   merge(services_by_state...)

--- a/src/kroki/service.jl
+++ b/src/kroki/service.jl
@@ -16,6 +16,27 @@ const DEFAULT_ENDPOINT = "https://kroki.io"
 "The currently active Kroki service endpoint being used."
 const ENDPOINT = Ref{String}("https://kroki.io")
 
+"Path to the Docker Compose definitions for running a local Kroki service."
+const SERVICE_DEFINITION_FILE = realpath(
+  "$(@__DIR__)/../../support/docker-services.yml"
+)
+
+"Helper function for executing Docker Compose commands."
+function executeDockerCompose(cmd::Vector{String})
+  captured_stdout = IOBuffer()
+
+  run(pipeline(
+    `docker-compose --file $(SERVICE_DEFINITION_FILE) --project-name krokijl $cmd`;
+    stdout = captured_stdout
+  ))
+
+  String(take!(captured_stdout))
+end
+executeDockerCompose(cmd::String) = executeDockerCompose([cmd])
+# The function should be called through indirection in cases where it needs to
+# be mocked out in tests
+const EXECUTE_DOCKER_COMPOSE = Ref{Any}(executeDockerCompose)
+
 """
 Sets the [`ENDPOINT`](@ref) using a fallback mechanism if no `endpoint` is
 provided.
@@ -40,6 +61,34 @@ function setEndpoint!(
 )
   ENDPOINT[] != endpoint && @info "Setting Kroki service endpoint to $(endpoint)."
   ENDPOINT[] = String(endpoint)
+end
+
+"""
+Returns a `NamedTuple` where the keys are the names of the service components
+and the values their corresponding 'running' state.
+
+# Examples
+```
+julia> status()
+(core = true, mermaid = false)
+```
+"""
+function status()
+  states_to_bool = Pair{String,Bool}["running" => true, "stopped" => false]
+
+  services_by_state = map(states_to_bool) do (state, running)::Pair{String,Bool}
+    services_with_state = EXECUTE_DOCKER_COMPOSE[](
+      ["ps", "--filter", "status=$state", "--services"]
+    )
+
+    service_symbols = Symbol.(
+      split(services_with_state, '\n'; keepempty = false)
+    )
+
+    (; zip(service_symbols, Iterators.repeated(running))... )
+  end
+
+  merge(services_by_state...)
 end
 
 # Ensure `ENDPOINT` has a valid value

--- a/src/kroki/service.jl
+++ b/src/kroki/service.jl
@@ -1,6 +1,10 @@
 """
 Defines functions and constants managing the Kroki service the rest of the
 package uses to render diagrams. These services can be either local or remote.
+
+This module also enables management of a local service instance, provided
+[Docker](https://docker.com) and [Docker
+Compose](https://docs.docker.com/compose/) are available on the system.
 """
 module Service
 
@@ -85,7 +89,8 @@ environment variable is also not present the [`DEFAULT_ENDPOINT`](@ref) is
 used.
 
 This can, for instance, be used in cases where a [privately hosted
-instance](https://docs.kroki.io/kroki/setup/install/) is available.
+instance](https://docs.kroki.io/kroki/setup/install/) is available or when a
+local service has been [`start!`](@ref)ed.
 
 Returns the value that [`ENDPOINT`](@ref) got set to.
 
@@ -99,6 +104,20 @@ function setEndpoint!(
 )
   ENDPOINT[] != endpoint && @info "Setting Kroki service endpoint to $(endpoint)."
   ENDPOINT[] = String(endpoint)
+end
+
+"""
+Starts the Kroki service components on the local system, optionally, ensuring
+[`ENDPOINT`](@ref) points to them.
+
+Pass `false` to the function to prevent the [`ENDPOINT`](@ref) from being
+updated. The default behavior is to update.
+"""
+function start!(update_endpoint::Bool = true)
+  @info "Starting Kroki service components."
+  EXECUTE_DOCKER_COMPOSE[](["up", "--detach"])
+  update_endpoint && setEndpoint!("http://localhost:8000")
+  return
 end
 
 """

--- a/support/docker-services.yml
+++ b/support/docker-services.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+ core:
+   image: yuzutech/kroki
+   environment:
+     - KROKI_BPMN_HOST=bpmn
+     - KROKI_BLOCKDIAG_HOST=blockdiag
+     - KROKI_MERMAID_HOST=mermaid
+     # Enable inclusion of external PlantUML descriptions and Vega datasets
+     - KROKI_SAFE_MODE=unsafe
+   ports:
+     - 8000:8000
+ blockdiag:
+   image: yuzutech/kroki-blockdiag
+ bpmn:
+   image: yuzutech/kroki-bpmn
+ mermaid:
+   image: yuzutech/kroki-mermaid

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+SimpleMock = "a896ed2c-15a5-4479-b61d-a0e88e2a1d25"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/kroki/service_test.jl
+++ b/test/kroki/service_test.jl
@@ -1,8 +1,16 @@
 module ServiceTest
 
-using Kroki.Service: DEFAULT_ENDPOINT, DockerComposeExecutionError, ENDPOINT,
-                     EXECUTE_DOCKER_COMPOSE, executeDockerCompose,
-                     setEndpoint!, start!, status, stop!, update!
+using Kroki.Service:
+  DEFAULT_ENDPOINT,
+  DockerComposeExecutionError,
+  ENDPOINT,
+  EXECUTE_DOCKER_COMPOSE,
+  executeDockerCompose,
+  setEndpoint!,
+  start!,
+  status,
+  stop!,
+  update!
 using SimpleMock
 using Test: @testset, @test, @test_logs
 
@@ -54,7 +62,9 @@ end
       @testset "logs `ENDPOINT` updates only if changed" begin
         expected_endpoint = "http://logged.endpoint.jl"
 
-        @test_logs (:info, "Setting Kroki service endpoint to $(expected_endpoint).") setEndpoint!(expected_endpoint)
+        @test_logs (:info, "Setting Kroki service endpoint to $(expected_endpoint).") setEndpoint!(
+          expected_endpoint,
+        )
         @test_logs setEndpoint!(expected_endpoint)
       end
     end
@@ -108,7 +118,8 @@ end
 
           # The following explicitly uses `match_mode=:any` to prevent having
           # to specify log messages caused by changes to `ENDPOINT`
-          returned = @test_logs (:info, "Starting Kroki service components.") match_mode=:any start!()
+          returned = @test_logs (:info, "Starting Kroki service components.") match_mode =
+            :any start!()
 
           # Ensure nothing gets returned from a call to `start!` instead of
           # `Process`es from the `docker-compose` execution
@@ -138,15 +149,11 @@ end
     end
 
     @testset "`status` reports individual Kroki service component status" begin
-      status_mock = Mock((cmd::Vector{String}) -> (
-        any(cmd .== "status=running")
-        ? """
-          core
-          blockdiag
-          mermaid
-          """
-        : "bpmn"
-      ))
+      status_mock = Mock((cmd::Vector{String}) -> (any(cmd .== "status=running") ? """
+                                                                                   core
+                                                                                   blockdiag
+                                                                                   mermaid
+                                                                                   """ : "bpmn"))
 
       mockExecuteDockerCompose(status_mock) do _executeDockerCompose
         service_statuses = status()
@@ -158,11 +165,11 @@ end
 
         @test called_with(
           _executeDockerCompose,
-          ["ps", "--filter", "status=running", "--services"]
+          ["ps", "--filter", "status=running", "--services"],
         )
         @test called_with(
           _executeDockerCompose,
-          ["ps", "--filter", "status=stopped", "--services"]
+          ["ps", "--filter", "status=stopped", "--services"],
         )
       end
     end
@@ -181,7 +188,8 @@ end
 
         # The following explicitly uses `match_mode=:any` to prevent having to
         # specify log messages caused by changes to `ENDPOINT`
-        returned = @test_logs (:info, "Stopping Kroki service components.") match_mode=:any stop!()
+        returned = @test_logs (:info, "Stopping Kroki service components.") match_mode =
+          :any stop!()
 
         # Ensure nothing gets returned from a call to `stop!` instead of
         # `Process`es from the `docker-compose` execution

--- a/test/kroki/service_test.jl
+++ b/test/kroki/service_test.jl
@@ -1,0 +1,55 @@
+module ServiceTest
+
+using Kroki.Service: DEFAULT_ENDPOINT, ENDPOINT, setEndpoint!
+using Test: @testset, @test, @test_logs
+
+@testset "Service" begin
+  @testset "`ENDPOINT`" begin
+    # Keep track of the original endpoint, so it can later be restored after
+    # all tests have finished running. This should be robust with respect to
+    # errors in the inner `TestSet`s
+    original_endpoint = ENDPOINT[]
+
+    @testset "`setEndpoint!`" begin
+      @testset "with `endpoint` adjusts `ENDPOINT` to `endpoint`" begin
+        expected_endpoint = "http://specific.endpoint.jl"
+
+        setEndpoint!(expected_endpoint)
+
+        @test ENDPOINT[] === expected_endpoint
+      end
+
+      @testset "without `endpoint` adjusts `ENDPOINT` to" begin
+        @testset "`KROKI_ENDPOINT` environment variable if set" begin
+          expected_endpoint = "http://from.environment.jl"
+          withenv("KROKI_ENDPOINT" => expected_endpoint) do
+            setEndpoint!()
+            @test ENDPOINT[] === expected_endpoint
+          end
+        end
+
+        @testset "`DEFAULT_ENDPOINT` otherwise" begin
+          # Force the `KROKI_ENDPOINT` environment variable to be unset, as it
+          # may be set outside the scope of the tests which would cause this
+          # test to fail
+          withenv("KROKI_ENDPOINT" => nothing) do
+            setEndpoint!()
+            @test ENDPOINT[] === DEFAULT_ENDPOINT
+          end
+        end
+      end
+
+      @testset "logs `ENDPOINT` updates only if changed" begin
+        expected_endpoint = "http://logged.endpoint.jl"
+
+        @test_logs (:info, "Setting Kroki service endpoint to $(expected_endpoint).") setEndpoint!(expected_endpoint)
+        @test_logs setEndpoint!(expected_endpoint)
+      end
+    end
+
+    # Restore the original endpoint
+    ENDPOINT[] = original_endpoint
+  end
+end
+
+end

--- a/test/kroki/service_test.jl
+++ b/test/kroki/service_test.jl
@@ -74,6 +74,20 @@ end
   end
 
   @testset "local instance management" begin
+    @static if Sys.which("docker-compose") !== nothing
+      @testset "wraps `docker-compose` with local service definitions" begin
+        status_report = executeDockerCompose("ps")
+
+        # Verify known pieces of `docker-compose ps` output are returned
+        @test occursin("Name", status_report)
+        @test occursin("Command", status_report)
+        @test occursin("State", status_report)
+        @test occursin("Ports", status_report)
+      end
+    else
+      @test_skip "Tests requiring `docker-compose` are skipped"
+    end
+
     @testset "`executeDockerCompose` throws descriptive errors indicating" begin
       @testset "dependencies are missing" begin
         try

--- a/test/kroki/service_test.jl
+++ b/test/kroki/service_test.jl
@@ -2,7 +2,7 @@ module ServiceTest
 
 using Kroki.Service: DEFAULT_ENDPOINT, DockerComposeExecutionError, ENDPOINT,
                      EXECUTE_DOCKER_COMPOSE, executeDockerCompose,
-                     setEndpoint!, status
+                     setEndpoint!, status, update!
 using SimpleMock
 using Test: @testset, @test, @test_logs
 
@@ -120,6 +120,15 @@ end
           _executeDockerCompose,
           ["ps", "--filter", "status=stopped", "--services"]
         )
+      end
+    end
+
+    @testset "`update!` pulls Kroki service component Docker images" begin
+      mockExecuteDockerCompose(Mock()) do _executeDockerCompose
+        # Ensure nothing gets returned from a call to `update!` instead of
+        # `Process`es from the `docker-compose` execution
+        @test update!() === nothing
+        @test called_with(_executeDockerCompose, ["pull", "--quiet"])
       end
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,31 +110,6 @@ end
         InvalidOutputFormatError,
       )
     end
-
-    @testset "`KROKI_ENDPOINT` environment variable" begin
-      # The instance of the Kroki service that is used for rendering can be
-      # controlled through the `KROKI_ENDPOINT` environment variable. The most
-      # straight-forward way for testing this is by pointing to an invalid
-      # endpoint and testing for a corresponding connection error
-      expected_diagram_type = :plantuml
-      expected_service_host = "https://localhost"
-
-      withenv("KROKI_ENDPOINT" => expected_service_host) do
-        try
-          render(Diagram(expected_diagram_type, "A -> B: C"), "svg")
-        catch exception
-          buffer = IOBuffer()
-          showerror(buffer, exception)
-          rendered_buffer = String(take!(buffer))
-
-          @test occursin("ECONNREFUSED", rendered_buffer)
-          @test occursin(
-            "$(expected_service_host)/$(expected_diagram_type)",
-            rendered_buffer,
-          )
-        end
-      end
-    end
   end
 
   @testset "string literal shorthand for diagram types" begin
@@ -187,6 +162,8 @@ end
       @test rendered_output == svgbob_diagram.specification
     end
   end
+
+  include("./kroki/service_test.jl")
 end
 
 end


### PR DESCRIPTION
This PR extends and improves the management of the Kroki service the package integrates with.

It adds a more structured approach to managing the endpoint of the Kroki service and a number of functions to manage (i.e. start/stop/update) a local instance of the Kroki service provided [Docker](https://docker.com) and [Docker Compose](https://docs.docker.com/compose/) are installed on the system.