### PR TITLE
Stop testing on nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,6 @@ jobs:
         version:
           - '1.6'
           - '1.7'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
`SimpleMock` appears to have issues with nightly versions of Julia due to its dependency on Cassette, see JuliaTesting/SimpleMock#13. This is causing failures in CI, e.g.https://github.com/bauglir/Kroki.jl/runs/7020848187#step:5:82.

Given that most people will likely be using this package on stable releases anyway and the pace at which this package evolves, there doesn't seem to be too much gain in testing on nightly to begin with.