### PR TITLE
Support loading diagram specifications from file

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -30,6 +30,7 @@ Filter = m -> endswith("$m", "_str")
 ## Private
 
 ```@docs
+DiagramPathOrSpecificationError
 InvalidDiagramSpecificationError
 InvalidOutputFormatError
 LIMITED_DIAGRAM_SUPPORT

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -147,6 +147,24 @@ svgbob"""
 """
 ```
 
+### Loading from a file
+
+Instead of directly specifying a diagram, [`Diagram`](@ref)s can also load the
+specifications from files. This is particularly useful when creating diagrams
+using other tooling, e.g. [Structurizr](https://structurizr.com) or
+[Excalidraw](https://excalidraw.com), or when sharing diagram definitions
+across documentation.
+
+To load a diagram from a file, specify the path of the file as the `path`
+keyword argument to [`Diagram`](@ref).
+
+```@example diagrams
+Diagram(
+  :structurizr;
+  path = joinpath(@__DIR__, "..", "architecture", "workspace.dsl"),
+)
+```
+
 ## Rendering to a specific format
 
 To render to a specific format, explicitly call the [`render`](@ref) function

--- a/test/assets/plantuml-example.puml
+++ b/test/assets/plantuml-example.puml
@@ -1,0 +1,6 @@
+@startuml
+
+Bob -> Alice: Hi!
+Alice -> Bob: Hi!
+
+@enduml


### PR DESCRIPTION
Sometimes, it's easier to have diagrams contained in separate files. For instance, when using tools like [Structurizr](https://structurizr.com) or [Excalidraw](https://excalidraw.com), or when a single diagram should be included in multiple places.

This PR adds an additional `Diagram` constructor that accepts _either_ a `path` or a `specification`. The latter of these is effectively the same as `Diagram(type::Symbol, specification::AbstractString)`, but included for API-parity.