### PR TITLE
Add `Diagram` constructors to the public API explicitly

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,6 +9,8 @@ CurrentModule = Kroki
 ```@docs
 Kroki
 Diagram
+Diagram(::Symbol, ::AbstractString)
+Diagram(::Symbol; ::Union{Nothing,AbstractString}, ::Union{Nothing,AbstractString})
 render
 ```
 

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -71,13 +71,13 @@ struct Diagram
   value is case-insensitive.
   """
   type::Symbol
-
-  """
-  Constructs a [`Diagram`](@ref) from the `specification` for a specific `type`
-  of diagram.
-  """
-  Diagram(type::Symbol, specification::AbstractString) = new(specification, type)
 end
+
+"""
+Constructs a [`Diagram`](@ref) from the `specification` for a specific `type`
+of diagram.
+"""
+Diagram(type::Symbol, specification::AbstractString) = Diagram(specification, type)
 
 """
 Constructs a [`Diagram`](@ref) from the `specification` for a specific `type`

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -83,7 +83,7 @@ Diagram(type::Symbol, specification::AbstractString) = Diagram(specification, ty
 Constructs a [`Diagram`](@ref) from the `specification` for a specific `type`
 of diagram, or loads the `specification` from the provided `path`.
 
-Specifying both, or neither, keyword arguments is invalid.
+Specifying both keyword arguments, or neither, is invalid.
 """
 function Diagram(
   type::Symbol;

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -30,24 +30,6 @@ const Maybe{T} = Union{Nothing, T} where {T}
 """
 A representation of a diagram that can be rendered by a Kroki service.
 
-# Constructors
-
-```
-Diagram(type::Symbol, specification::AbstractString)
-```
-
-Constructs a `Diagram` from the `specification` for a specific `type` of
-diagram.
-
-```
-Diagram(type::Symbol; path::AbstractString, specification::AbstractString)
-```
-
-Constructs a `Diagram` from the `specification` for a specific `type` of
-diagram, or loads the `specification` from the provided `path`.
-
-Specifying both, or neither, keyword arguments is invalid.
-
 # Examples
 
 ```


### PR DESCRIPTION
#12 duplicated the docstrings for the `Diagram` constructors in the docstring of the `Diagram` type. Instead, the methods should have been explicitly added to the API documentation to include their docstrings directly without duplication.