### PR TITLE
Add support for diagram options

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -165,6 +165,72 @@ Diagram(
 )
 ```
 
+### Diagram options
+
+Some diagram types support [diagram
+options](https://docs.kroki.io/kroki/setup/diagram-options) controlling their
+apearance. These options can be set when instantiating a [`Diagram`](@ref).
+
+For instance, the `workspace.dsl` file referenced in the previous section
+defines multiple diagrams. The diagram that is rendered in the previous section
+is picked randomly from this set every time the documentation is generated. The
+[Structurizr](https://docs.kroki.io/kroki/setup/diagram-options/#_structurizr)
+diagrams support a `view-key` option to indicate which diagram should be
+rendered from the set defined in the file.
+
+```@example diagrams
+structurizr_diagram = Diagram(
+  :structurizr;
+  path = joinpath(@__DIR__, "..", "architecture", "workspace.dsl"),
+  options = Dict("view-key" => "KrokiService-Container")
+)
+```
+
+Another use case is specifying [a theme for PlantUML
+diagrams](https://docs.kroki.io/kroki/setup/diagram-options/#_plantuml).
+
+```@example diagrams
+Diagram(:plantuml, "Kroki -> Julia: Hello"; options = Dict("theme" => "amiga"))
+```
+
+```@example diagrams
+Diagram(:plantuml, "Julia -> Kroki: Hello!"; options = Dict("theme" => "crt-amber"))
+```
+
+Instead of specifying diagram options at [`Diagram`](@ref) construction, they
+can also be passed directly to the [`render`](@ref) function. For instance, to
+select a different diagram from the set of Structurizr diagrams previously
+loaded from file.
+
+```@setup diagrams
+# A helper struct to show the result of `render` within `Documenter`
+struct DocumenterSvg
+  svg::Vector{UInt8}
+end
+function Base.show(io::IO, ::MIME"image/svg+xml", (; svg)::DocumenterSvg)
+  write(io, svg)
+end
+```
+
+```@example diagrams
+# A helper wrapper to ensure the output of `render` can be visualized directly
+# within `Documenter`
+DocumenterSvg(
+  render(
+    structurizr_diagram, "svg";
+    options = Dict("view-key" => "Krokijl-Krokijl-Component")
+  )
+)
+```
+
+!!! info "A note on `view-key`s"
+
+    The `view-key`s for Structurizr diagrams can either be dynamic and obtained
+    from the [Structurizr (Lite) software](https://structurizr.com/help/lite),
+    or they can be specified as [the second argument to 'view definitions'
+    using the Structurizr
+    DSL](https://github.com/structurizr/dsl/blob/master/docs/language-reference.md#views).
+
 ## Rendering to a specific format
 
 To render to a specific format, explicitly call the [`render`](@ref) function

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -128,6 +128,11 @@ UriSafeBase64Payload(diagram::Diagram) = foldl(
 Renders a [`Diagram`](@ref) through a Kroki service to the specified output
 format.
 
+Allows the specification of [diagram
+options](https://docs.kroki.io/kroki/setup/diagram-options) through the
+`options` keyword. The `options` default to those specified on the
+[`Diagram`](@ref).
+
 If the Kroki service responds with an error, throws an
 [`InvalidDiagramSpecificationError`](@ref
 Kroki.Exceptions.InvalidDiagramSpecificationError) or
@@ -140,7 +145,11 @@ _SVG output is supported for all [`Diagram`](@ref) types_. See [Kroki's
 website](https://kroki.io/#support) for an overview of other supported output
 formats per diagram type. Note that this list may not be entirely up-to-date.
 """
-render(diagram::Diagram, output_format::AbstractString) =
+render(
+  diagram::Diagram,
+  output_format::AbstractString;
+  options::Dict{String, String} = diagram.options,
+) =
   try
     getfield(
       request(
@@ -154,6 +163,11 @@ render(diagram::Diagram, output_format::AbstractString) =
           ],
           '/',
         ),
+        # Pass all diagram options as headers to Kroki by prepending the
+        # necessary prefix to all provided `options`. This ensures this package
+        # does not have to be updated whenever new options are added to the
+        # service
+        "Kroki-Diagram-Options-" .* keys(options) .=> values(options),
       ),
       :body,
     )

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -44,7 +44,7 @@ julia> Kroki.Diagram(:PlantUML, "Kroki -> Julia: Hello Julia!")
      └─────┘          └─────┘
 ```
 """
-struct Diagram
+Base.@kwdef struct Diagram
   "The textual specification of the diagram."
   specification::AbstractString
 

--- a/test/kroki/string_literals_test.jl
+++ b/test/kroki/string_literals_test.jl
@@ -18,7 +18,7 @@ using Kroki: Diagram, @mermaid_str, @plantuml_str
 
   string_literal_mermaid = mermaid"graph TD; A --> B"
   diagram_type_mermaid = Diagram(:mermaid, "graph TD; A --> B")
-  @test string_literal_mermaid == diagram_type_mermaid
+  @test "$string_literal_mermaid" == "$diagram_type_mermaid"
 
   @testset "support interpolation" begin
     # String macros do no support string interpolation out-of-the-box, this

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,20 @@ end
 
       @test diagram.specification === expected_specification
       @test diagram.type === expected_type
+
+      @testset "optionally accepts `options`" begin
+        expected_options = Dict("key" => "value")
+
+        diagram = Diagram(
+          options = expected_options,
+          specification = expected_specification,
+          type = expected_type,
+        )
+
+        @test diagram.options === expected_options
+        @test diagram.specification === expected_specification
+        @test diagram.type === expected_type
+      end
     end
 
     @testset "through `type` and `specification` positional arguments" begin
@@ -33,6 +47,16 @@ end
 
       @test diagram.specification === expected_specification
       @test diagram.type === expected_type
+
+      @testset "optionally accepts `options`" begin
+        expected_options = Dict("foo" => "bar")
+
+        diagram = Diagram(expected_type, expected_specification; options = expected_options)
+
+        @test diagram.options === expected_options
+        @test diagram.specification === expected_specification
+        @test diagram.type === expected_type
+      end
     end
 
     @testset "through `type` positional argument with keyword arguments" begin
@@ -43,6 +67,15 @@ end
         diagram = Diagram(:plantuml; path = diagram_path)
 
         @test diagram.specification === expected_specification
+      end
+
+      @testset "optionally accepts `options`" begin
+        expected_options = Dict("key" => "value")
+
+        diagram =
+          Diagram(:plantuml; options = expected_options, specification = "A -> B: C")
+
+        @test diagram.options === expected_options
       end
 
       @testset "providing the `specification` keyword argument stores it" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,6 +130,27 @@ end
       # after the render, these should be ignored when matching
       @test endswith(rendered, r"</svg>\s?")
     end
+
+    @testset "takes `options` into account" begin
+      expected_theme_name = "materia"
+      options = Dict{String, String}("theme" => expected_theme_name)
+      diagram = Diagram(:plantuml, "A -> B: C"; options)
+
+      @testset "defaults to `Diagram` options" begin
+        rendered = String(render(diagram, "svg"))
+
+        @test occursin("!theme $(expected_theme_name)", rendered)
+      end
+
+      @testset "allows definition at render-time" begin
+        expected_overridden_theme = "sketchy"
+        rendered = String(
+          render(diagram, "svg"; options = Dict("theme" => expected_overridden_theme)),
+        )
+
+        @test occursin("!theme $(expected_overridden_theme)", rendered)
+      end
+    end
   end
 
   @testset "`Base.show`" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,16 @@ end
 
 @testset "Kroki" begin
   @testset "`Diagram` instantiation" begin
+    @testset "through keyword arguments" begin
+      expected_specification = "[...]--[...]"
+      expected_type = :svgbob
+
+      diagram = Diagram(specification = expected_specification, type = expected_type)
+
+      @test diagram.specification === expected_specification
+      @test diagram.type === expected_type
+    end
+
     @testset "through `type` and `specification` positional arguments" begin
       expected_specification = "A -> B: C"
       expected_type = :plantuml

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,21 +15,33 @@ end
 
 @testset "Kroki" begin
   @testset "`Diagram` instantiation" begin
-    @testset "providing `path` loads the file as the `specification" begin
-      diagram_path = joinpath(@__DIR__, "assets", "plantuml-example.puml")
-      expected_specification = read(diagram_path, String)
+    @testset "through `type` and `specification` positional arguments" begin
+      expected_specification = "A -> B: C"
+      expected_type = :plantuml
 
-      diagram = Diagram(:plantml; path = diagram_path)
+      diagram = Diagram(expected_type, expected_specification)
 
       @test diagram.specification === expected_specification
+      @test diagram.type === expected_type
     end
 
-    @testset "providing `specification` stores it" begin
-      expected_specification = "A -> B: C"
+    @testset "through `type` positional argument with keyword arguments" begin
+      @testset "providing the `path` keyword argument loads a file as the `specification" begin
+        diagram_path = joinpath(@__DIR__, "assets", "plantuml-example.puml")
+        expected_specification = read(diagram_path, String)
 
-      diagram = Diagram(:plantuml; specification = expected_specification)
+        diagram = Diagram(:plantuml; path = diagram_path)
 
-      @test diagram.specification === expected_specification
+        @test diagram.specification === expected_specification
+      end
+
+      @testset "providing the `specification` keyword argument stores it" begin
+        expected_specification = "A -> B: C"
+
+        diagram = Diagram(:plantuml; specification = expected_specification)
+
+        @test diagram.specification === expected_specification
+      end
     end
   end
 


### PR DESCRIPTION
Some diagrams supported by Kroki have support for [diagram options](https://docs.kroki.io/kroki/setup/diagram-options) that affect their appearance. For instance, the theme of a PlantUML diagram can be updated, or a specific diagram from a set of Structurizr diagrams can be selected, etc.

This PR allows those options to be specified when instantiating a `Diagram` or when `render`ing one.