### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - name: Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: ./lcov.info
           env_vars: OS,JULIA

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,11 @@
 name: CI
 
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches:
+      - development
+      - main
 
 jobs:
   Test:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - name: Codecov

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       OS: ${{ matrix.os }}
       JULIA: ${{ matrix.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - name: Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/CodeFormattingCheck.yml
+++ b/.github/workflows/CodeFormattingCheck.yml
@@ -7,7 +7,7 @@ on:
       - development
 
 jobs:
-  build:
+  code-format-check:
     runs-on: ubuntu-latest
     steps:
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CodeFormattingCheck.yml
+++ b/.github/workflows/CodeFormattingCheck.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v1
         with:
           version: '1.7.3'
 

--- a/.github/workflows/CodeFormattingCheck.yml
+++ b/.github/workflows/CodeFormattingCheck.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           version: '1.7.3'
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install JuliaFormatter and format
         run: |
           julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="1.0.3"))'

--- a/.github/workflows/CodeFormattingCheck.yml
+++ b/.github/workflows/CodeFormattingCheck.yml
@@ -1,14 +1,14 @@
 name: Code Format Check
 
 on:
+  pull_request:
   push:
     branches:
       - development
-  pull_request:
 
 jobs:
   build:
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-latest
     steps:
       - uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -8,7 +8,7 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v1
         with:
           version: 1.4
       - name: Install CompatHelper

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: julia-actions/setup-julia@v1
         with:
-          version: 1.4
+          version: '1.7.3'
       - name: Install CompatHelper
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: Update Dependencies

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -6,7 +6,8 @@ on:
     branches:
       - development
       - main
-    tags: 'v*'
+    tags:
+      - v*
 
 jobs:
   docs:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -13,7 +13,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
       - name: Install dependencies
         run: |

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,6 +23,6 @@ jobs:
             @semantic-release/git
             @google/semantic-release-replace-plugin
       - name: Notify JuliaRegistrator of new release
-        uses: peter-evans/commit-comment@v1
+        uses: peter-evans/commit-comment@v2
         with:
           body: '@JuliaRegistrator register branch=main'

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          semantic_version: 17.1.1
+          semantic_version: 19.0.3
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
         env:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           semantic_version: 17.1.1
           extra_plugins: |


### PR DESCRIPTION
The CI workflows haven't been updated, e.g. versions, etc. in almost 2 years. It's about time they received an update and some fine tuning, e.g. not running test suites twice for PRs.