### PR TITLE
Add support for diagrams.net/draw.io

### DIFF
--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -52,6 +52,13 @@ workspace {
         kroki_core -> this "Defers `bpmn` diagrams to"
       }
 
+      container "Diagrams.net/Draw.io Service" {
+        description "Renders 'Diagrams.net/Draw.io' diagrams."
+        url https://diagrams.net
+
+        kroki_core -> this "Defers `diagramsnet` diagrams to"
+      }
+
       container "Excalidraw Service" {
         description "Renders 'Excalidraw' diagrams."
         url https://excalidraw.com

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -199,6 +199,7 @@ const LIMITED_DIAGRAM_SUPPORT = Dict{AbstractString, Tuple{Symbol, Vararg{Symbol
     :seqdiag,
     :actdiag,
     :nwdiag,
+    :diagramsnet,
     :packetdiag,
     :rackdiag,
     :c4plantuml,

--- a/support/docker-services.yml
+++ b/support/docker-services.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - KROKI_BLOCKDIAG_HOST=blockdiag
       - KROKI_BPMN_HOST=bpmn
+      - KROKI_DIAGRAMSNET_HOST=diagramsnet
       - KROKI_EXCALIDRAW_HOST=excalidraw
       - KROKI_MERMAID_HOST=mermaid
       # Enable inclusion of, for instance, external PlantUML descriptions and
@@ -21,6 +22,8 @@ services:
     image: yuzutech/kroki-blockdiag
   bpmn:
     image: yuzutech/kroki-bpmn
+  diagramsnet:
+    image: yuzutech/kroki-diagramsnet
   excalidraw:
     image: yuzutech/kroki-excalidraw
   mermaid:


### PR DESCRIPTION
This is considered experimental by the upstream Kroki service. At the time of adding this support, this means it will only work with a local instance of Kroki and the associated companion container (added through 19764fb5003b4757dabda44899022cca52bb1a19). See [Kroki's documentation](https://docs.kroki.io/kroki/setup/install/#_companion_containers).

Once the upstream Kroki service moves support for these diagrams out of the 'experimental' phase, rendering these diagrams will just work in general.