### PR TITLE
Simplify 'string literal'/`Diagram` equivalence tests

### DIFF
--- a/test/kroki/string_literals_test.jl
+++ b/test/kroki/string_literals_test.jl
@@ -9,16 +9,28 @@ using Kroki: Diagram, @mermaid_str, @plantuml_str
   # specifying diagrams.
   #
   # This is not an exhaustive test as these are dynamically generated. The
-  # basic functionality is only verified for key diagram types
-  string_literal_plantuml = plantuml"A -> B: C"
-  diagram_type_plantuml = Diagram(:PlantUML, "A -> B: C")
-  # The leading newlines make sure the alignment of the plain text
-  # representations is identical across both calling methods
-  @test "\n$string_literal_plantuml" == "\n$diagram_type_plantuml"
+  # basic functionality is only verified for key diagram types.
+  #
+  # Note that the `specification`s and `type`s are compared directly. Comparing
+  # the resulting `Diagram`s directly compares their rendered versions which is
+  # a bit more finicky and duplicating test logic for `Base.show`
+  @testset "are equivalent to using `Diagram` constructors" begin
+    @testset "PlantUML" begin
+      string_literal = plantuml"A -> B: C"
+      diagram_constructor = Diagram(:plantuml, "A -> B: C")
 
-  string_literal_mermaid = mermaid"graph TD; A --> B"
-  diagram_type_mermaid = Diagram(:mermaid, "graph TD; A --> B")
-  @test "$string_literal_mermaid" == "$diagram_type_mermaid"
+      @test string_literal.specification === diagram_constructor.specification
+      @test string_literal.type === diagram_constructor.type
+    end
+
+    @testset "Mermaid" begin
+      string_literal = mermaid"graph TD; A --> B"
+      diagram_constructor = Diagram(:mermaid, "graph TD; A --> B")
+
+      @test string_literal.specification === diagram_constructor.specification
+      @test string_literal.type === diagram_constructor.type
+    end
+  end
 
   @testset "support interpolation" begin
     # String macros do no support string interpolation out-of-the-box, this


### PR DESCRIPTION
The string literals construct `Diagram`s, so instead of duplicating [`Base.show` tests](https://github.com/bauglir/Kroki.jl/blob/c8494c978fcf7385c1dc3c8ec6d066dc9a1dc9a8/test/runtests.jl#L156-L181) and comparing rendered versions of those `Diagram`s, whether the `Diagram`s are correctly created should be verified instead.