### PR TITLE
Extend diagram rendering capabilities

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -35,6 +35,7 @@ Modules = [ Kroki.StringLiterals ]
 
 ```@docs
 LIMITED_DIAGRAM_SUPPORT
+MIME_TO_RENDER_ARGUMENT_MAP
 UriSafeBase64Payload
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -11,6 +11,8 @@ Kroki
 Diagram
 Diagram(::Symbol, ::AbstractString)
 Diagram(::Symbol; ::Union{Nothing,AbstractString}, ::Union{Nothing,AbstractString})
+SUPPORTED_TEXT_PLAIN_SHOW_MIME_TYPES
+TEXT_PLAIN_SHOW_MIME_TYPE
 render
 ```
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -92,12 +92,12 @@ $alice -> $bob: Rendering diagrams!
 ## [The `Diagram` type](@id examples-diagram-type)
 
 String literals are effectively short-hands for instantiating a
-[`Diagram`](@ref Kroki.Diagram) for a specific type of diagram. In certain
-cases, it may be more straightforward, or even necessary, to directly
-instantiate a [`Diagram`](@ref Kroki.Diagram). For instance, when a type of
-diagram is supported by the Kroki service but support for it has not been added
-to this package. In those cases, basic functionality like rendering to an SVG
-should typically still work in line with the following examples.
+[`Diagram`](@ref) for a specific type of diagram. In certain cases, it may be
+more straightforward, or even necessary, to directly instantiate a
+[`Diagram`](@ref). For instance, when a type of diagram is supported by the
+Kroki service but support for it has not been added to this package. In those
+cases, basic functionality like rendering to an SVG should typically still work
+in line with the following examples.
 
 ```@example diagrams
 Diagram(:mermaid, """
@@ -114,7 +114,7 @@ graph TD
 
     When the diagram description contains special characters, e.g. `\`s, keep
     in mind that these need to be escaped for proper handling when
-    instantiating a [`Diagram`](@ref Kroki.Diagram).
+    instantiating a [`Diagram`](@ref).
 
     Escaping is not typically necessary when using [string literals](@ref
     api-string-literals).

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -278,3 +278,51 @@ write("mermaid_diagram.svg", render(mermaid_diagram, "svg"))
 ```
 
 ![Mermaid diagram as SVG example](mermaid_diagram.svg)
+
+## Controlling text rendering
+
+Some diagrams support rendering to text, e.g. PlantUML and Structurizr. This
+can be based on ASCII or Unicode character sets. Which character set is used,
+is controlled using the [`Kroki.TEXT_PLAIN_SHOW_MIME_TYPE`](@ref) variable.
+
+Setting a `text/plain` MIME type results in the use of the limited ASCII
+character set.
+
+```@setup diagrams
+text_plain_show_mime_type_backup = Kroki.TEXT_PLAIN_SHOW_MIME_TYPE[]
+```
+
+```@example diagrams
+plantuml_diagram = plantuml"""
+Kroki -> Documenter: I can render this as text in two ways!
+Kroki <- Documenter: Nice!
+"""
+
+Kroki.TEXT_PLAIN_SHOW_MIME_TYPE[] = MIME"text/plain"()
+println(sprint(show, MIME"text/plain"(), plantuml_diagram))
+```
+
+Setting a `text/plain; charset=utf-8` MIME type, which is the default, results
+in nicer looking diagrams due to the use of Unicode characters.
+
+```@example diagrams
+Kroki.TEXT_PLAIN_SHOW_MIME_TYPE[] = MIME"text/plain; charset=utf-8"()
+println(sprint(show, MIME"text/plain"(), plantuml_diagram))
+```
+
+Configuring an invalid MIME type results in an error upon rendering to a
+`text/plain` target.
+
+```@example diagrams
+Kroki.TEXT_PLAIN_SHOW_MIME_TYPE[] = MIME"not-a-known/mime-type"()
+
+try
+  sprint(show, MIME"text/plain"(), plantuml_diagram)
+catch exception
+  println(sprint(showerror, exception))
+end
+```
+
+```@setup diagrams
+Kroki.TEXT_PLAIN_SHOW_MIME_TYPE[] = text_plain_show_mime_type_backup
+```

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -229,6 +229,8 @@ const LIMITED_DIAGRAM_SUPPORT = Dict{MIME, Tuple{Symbol, Vararg{Symbol}}}(
 # that actually support the format
 Base.show(io::IO, ::MIME"application/pdf", diagram::Diagram) =
   write(io, render(diagram, "pdf"))
+Base.show(io::IO, ::MIME"image/jpeg", diagram::Diagram) =
+  write(io, render(diagram, "jpeg"))
 Base.show(io::IO, ::MIME"image/png", diagram::Diagram) =
   write(io, render(diagram, "png"))
 
@@ -240,6 +242,16 @@ Base.show(io::IO, ::MIME"image/svg+xml", diagram::Diagram) =
 
 Base.showable(::T, diagram::Diagram) where {T <: MIME} =
   Symbol(lowercase(String(diagram.type))) ∈ get(LIMITED_DIAGRAM_SUPPORT, T(), Tuple([]))
+
+# Calling `Base.show` for JPEGs is explicitly disabled, for the time being.
+# JPEG rendering is broken for all, supposedly supported, diagram types in the
+# Kroki service. Should the support be fixed in the service, this method can be
+# easily redefined by consuming software to support JPEG in case Kroki.jl has
+# not been updated and released.
+#
+# Note that this only affects automatic rendering of `Diagram`s to JPEGs in
+# supported environments. It is still possible to use `render` to render JPEGs
+Base.showable(::MIME"image/jpeg", ::Diagram) = false
 
 # The two-argument `Base.show` version is used to render the "text/plain" MIME
 # type. Those `Diagram` types that can render text versions, e.g. PlantUML,

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -180,8 +180,8 @@ Some MIME types are not supported by all diagram types, this constant contains
 all these limitations. The union of all values corresponds to all supported
 [`Diagram`](@ref) `type`s.
 """
-const LIMITED_DIAGRAM_SUPPORT = Dict{AbstractString, Tuple{Symbol, Vararg{Symbol}}}(
-  "application/pdf" => (
+const LIMITED_DIAGRAM_SUPPORT = Dict{MIME, Tuple{Symbol, Vararg{Symbol}}}(
+  MIME"application/pdf"() => (
     :blockdiag,
     :seqdiag,
     :actdiag,
@@ -193,8 +193,8 @@ const LIMITED_DIAGRAM_SUPPORT = Dict{AbstractString, Tuple{Symbol, Vararg{Symbol
     :vega,
     :vegalite,
   ),
-  "image/jpeg" => (:c4plantuml, :erd, :graphviz, :plantuml, :umlet),
-  "image/png" => (
+  MIME"image/jpeg"() => (:c4plantuml, :erd, :graphviz, :plantuml, :umlet),
+  MIME"image/png"() => (
     :blockdiag,
     :seqdiag,
     :actdiag,
@@ -215,9 +215,9 @@ const LIMITED_DIAGRAM_SUPPORT = Dict{AbstractString, Tuple{Symbol, Vararg{Symbol
   ),
   # Although all diagram types support SVG, these _only_ support SVG so are
   # included separately
-  "image/svg+xml" =>
+  MIME"image/svg+xml"() =>
     (:bpmn, :bytefield, :excalidraw, :nomnoml, :pikchr, :svgbob, :wavedrom),
-  "text/plain" => (:c4plantuml, :plantuml),
+  MIME"text/plain"() => (:c4plantuml, :plantuml),
 )
 
 # `Base.show` methods should only be defined for diagram types that actually
@@ -227,10 +227,10 @@ const LIMITED_DIAGRAM_SUPPORT = Dict{AbstractString, Tuple{Symbol, Vararg{Symbol
 # available within [`Diagram`](@ref) instances, the `show` method is defined
 # generically, but then restricted using `Base.showable` to only those types
 # that actually support the format
-Base.show(io::IO, ::MIME{Symbol("image/png")}, diagram::Diagram) =
+Base.show(io::IO, ::MIME"image/png", diagram::Diagram) =
   write(io, render(diagram, "png"))
-Base.showable(::MIME{Symbol("image/png")}, diagram::Diagram) =
-  diagram.type ∈ LIMITED_DIAGRAM_SUPPORT["image/png"]
+Base.showable(::MIME"image/png", diagram::Diagram) =
+  diagram.type ∈ LIMITED_DIAGRAM_SUPPORT[MIME"image/png"()]
 
 # SVG output is supported by _all_ diagram types, so there's no additional
 # checking for support. This makes sure SVG output also works for new diagram

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -227,6 +227,8 @@ const LIMITED_DIAGRAM_SUPPORT = Dict{MIME, Tuple{Symbol, Vararg{Symbol}}}(
 # available within [`Diagram`](@ref) instances, the `show` method is defined
 # generically, but then restricted using `Base.showable` to only those types
 # that actually support the format
+Base.show(io::IO, ::MIME"application/pdf", diagram::Diagram) =
+  write(io, render(diagram, "pdf"))
 Base.show(io::IO, ::MIME"image/png", diagram::Diagram) =
   write(io, render(diagram, "png"))
 

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -229,21 +229,22 @@ const LIMITED_DIAGRAM_SUPPORT = Dict{MIME, Tuple{Symbol, Vararg{Symbol}}}(
 # that actually support the format
 Base.show(io::IO, ::MIME"image/png", diagram::Diagram) =
   write(io, render(diagram, "png"))
-Base.showable(::MIME"image/png", diagram::Diagram) =
-  diagram.type ∈ LIMITED_DIAGRAM_SUPPORT[MIME"image/png"()]
 
 # SVG output is supported by _all_ diagram types, so there's no additional
 # checking for support. This makes sure SVG output also works for new diagram
-# types if they get added to Kroki, but not yet to this package
+# types if they get added to the Kroki service, but not yet to this package
 Base.show(io::IO, ::MIME"image/svg+xml", diagram::Diagram) =
   write(io, render(diagram, "svg"))
+
+Base.showable(::T, diagram::Diagram) where {T <: MIME} =
+  Symbol(lowercase(String(diagram.type))) ∈ get(LIMITED_DIAGRAM_SUPPORT, T(), Tuple([]))
 
 # The two-argument `Base.show` version is used to render the "text/plain" MIME
 # type. Those `Diagram` types that can render text versions, e.g. PlantUML,
 # Structurizr, should render those. All others should render their
 # `specification`.
 function Base.show(io::IO, diagram::Diagram)
-  if Symbol(lowercase(string(diagram.type))) ∈ LIMITED_DIAGRAM_SUPPORT[MIME"text/plain"()]
+  if showable(MIME"text/plain"(), diagram)
     write(io, render(diagram, "utxt"))
   else
     write(io, diagram.specification)

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -193,7 +193,7 @@ const LIMITED_DIAGRAM_SUPPORT = Dict{MIME, Tuple{Symbol, Vararg{Symbol}}}(
     :vega,
     :vegalite,
   ),
-  MIME"image/jpeg"() => (:c4plantuml, :erd, :graphviz, :plantuml, :umlet),
+  MIME"image/jpeg"() => (:c4plantuml, :erd, :graphviz, :plantuml, :structurizr, :umlet),
   MIME"image/png"() => (
     :blockdiag,
     :seqdiag,
@@ -217,7 +217,7 @@ const LIMITED_DIAGRAM_SUPPORT = Dict{MIME, Tuple{Symbol, Vararg{Symbol}}}(
   # included separately
   MIME"image/svg+xml"() =>
     (:bpmn, :bytefield, :excalidraw, :nomnoml, :pikchr, :svgbob, :wavedrom),
-  MIME"text/plain"() => (:c4plantuml, :plantuml),
+  MIME"text/plain"() => (:c4plantuml, :plantuml, :structurizr),
 )
 
 # `Base.show` methods should only be defined for diagram types that actually
@@ -238,14 +238,17 @@ Base.showable(::MIME"image/png", diagram::Diagram) =
 Base.show(io::IO, ::MIME"image/svg+xml", diagram::Diagram) =
   write(io, render(diagram, "svg"))
 
-# PlantUML is capable of rendering textual representations, all other diagram
-# types are not
-Base.show(io::IO, diagram::Diagram) =
-  if endswith(lowercase("$(diagram.type)"), "plantuml")
+# The two-argument `Base.show` version is used to render the "text/plain" MIME
+# type. Those `Diagram` types that can render text versions, e.g. PlantUML,
+# Structurizr, should render those. All others should render their
+# `specification`.
+function Base.show(io::IO, diagram::Diagram)
+  if Symbol(lowercase(string(diagram.type))) ∈ LIMITED_DIAGRAM_SUPPORT[MIME"text/plain"()]
     write(io, render(diagram, "utxt"))
   else
     write(io, diagram.specification)
   end
+end
 
 include("./kroki/string_literals.jl")
 @reexport using .StringLiterals

--- a/src/kroki/exceptions.jl
+++ b/src/kroki/exceptions.jl
@@ -96,4 +96,27 @@ function RenderError(diagram::Diagram, exception::StatusError)
 end
 RenderError(::Diagram, exception::Exception) = exception
 
+"""
+An `Exception` to be thrown when the `selected_mime_type` is not an element of
+the set of `supported_mime_types`.
+"""
+struct UnsupportedMIMETypeError <: Exception
+  "The selected `MIME` type that is not supported."
+  selected_mime_type::MIME
+
+  "The set of supported `MIME` types."
+  supported_mime_types::Set{MIME}
+end
+
+Base.showerror(io::IO, error::UnsupportedMIMETypeError) = join(
+  io,
+  [
+    "The selected `MIME` type must be one of `",
+    join(error.supported_mime_types, "`, `", "` or `"),
+    "`. Got `",
+    error.selected_mime_type,
+    "`.",
+  ],
+)
+
 end

--- a/test/kroki/exceptions_test.jl
+++ b/test/kroki/exceptions_test.jl
@@ -7,7 +7,8 @@ using Kroki.Exceptions:
   DiagramPathOrSpecificationError,
   InvalidDiagramSpecificationError,
   InvalidOutputFormatError,
-  StatusError # Imported from HTTP through Kroki
+  StatusError, # Imported from HTTP through Kroki
+  UnsupportedMIMETypeError
 using Kroki.Service: setEndpoint!
 
 testRenderError(
@@ -113,6 +114,22 @@ end
       end
 
       setEndpoint!()
+    end
+  end
+
+  @testset "`UnsupportedMIMETypeError`" begin
+    @testset "rendering" begin
+      selected_mime_type = MIME"text/plain"()
+      supported_mime_types = Set([MIME"application/pdf"(), MIME"image/png"()])
+
+      rendered_error = sprint(
+        showerror,
+        UnsupportedMIMETypeError(selected_mime_type, supported_mime_types),
+      )
+
+      @test startswith(rendered_error, "The selected `MIME` type")
+      @test occursin(join(supported_mime_types, "`, `", "` or `"), rendered_error)
+      @test occursin("Got `$(selected_mime_type)`", rendered_error)
     end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,6 +165,7 @@ end
     @test_throws(InvalidOutputFormatError, sprint(show, MIME"image/png"(), svgbob_diagram))
     @test !showable(MIME"image/png"(), svgbob_diagram)
     testShowMethodRenders(svgbob_diagram, MIME"image/svg+xml"(), "svg")
+    @test !showable("non-existent/mime-type", svgbob_diagram)
 
     plantuml_diagram = Diagram(:PlantUML, "A -> B: C")
     testShowMethodRenders(plantuml_diagram, MIME"image/png"(), "png")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,6 +200,11 @@ end
     @test !showable("application/pdf", svgbob_diagram)
     @test_throws(InvalidOutputFormatError, sprint(show, MIME"image/png"(), svgbob_diagram))
     @test !showable(MIME"image/png"(), svgbob_diagram)
+    @test_throws(
+      InvalidOutputFormatError,
+      show(IOBuffer(), MIME"image/jpeg"(), svgbob_diagram)
+    )
+    @test !showable("image/jpeg", svgbob_diagram)
     testShowMethodRenders(svgbob_diagram, MIME"image/svg+xml"(), "svg")
     @test !showable("non-existent/mime-type", svgbob_diagram)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using Kroki.Exceptions: InvalidOutputFormatError
 
 function testShowMethodRenders(
   diagram::Diagram,
-  mime_type::AbstractString,
+  mime_type::MIME,
   render_output_format::AbstractString,
 )
   @test sprint(show, mime_type, diagram) == String(render(diagram, render_output_format))
@@ -158,25 +158,25 @@ end
     # `InvalidOutputFormatError`s when called directly.
     #
     # To prevent compatible `AbstractDisplay`s from trying to render
-    # incompatible diagram types in certain formats resulting in errors,
-    # `Base.showable` should be overridden to indicate the diagram cannot be
-    # rendered in the specified MIME type
+    # incompatible diagram types to unsuppored output formats, `Base.showable`
+    # should be overridden to indicate the diagram cannot be rendered in the
+    # specified MIME type
     svgbob_diagram = Diagram(:svgbob, "-->[_...__... ]")
-    @test_throws(InvalidOutputFormatError, sprint(show, "image/png", svgbob_diagram))
-    @test !showable("image/png", svgbob_diagram)
-    testShowMethodRenders(svgbob_diagram, "image/svg+xml", "svg")
+    @test_throws(InvalidOutputFormatError, sprint(show, MIME"image/png"(), svgbob_diagram))
+    @test !showable(MIME"image/png"(), svgbob_diagram)
+    testShowMethodRenders(svgbob_diagram, MIME"image/svg+xml"(), "svg")
 
     plantuml_diagram = Diagram(:PlantUML, "A -> B: C")
-    testShowMethodRenders(plantuml_diagram, "image/png", "png")
-    testShowMethodRenders(plantuml_diagram, "image/svg+xml", "svg")
+    testShowMethodRenders(plantuml_diagram, MIME"image/png"(), "png")
+    testShowMethodRenders(plantuml_diagram, MIME"image/svg+xml"(), "svg")
 
     @testset "`text/plain`" begin
       # PlantUML diagrams can be rendered nicely in text/plain based
       # environments
-      testShowMethodRenders(plantuml_diagram, "text/plain", "utxt")
+      testShowMethodRenders(plantuml_diagram, MIME"text/plain"(), "utxt")
 
       # Other diagram types should simply display their `specification`
-      @test sprint(show, "text/plain", svgbob_diagram) == svgbob_diagram.specification
+      @test sprint(show, MIME"text/plain"(), svgbob_diagram) == svgbob_diagram.specification
     end
   end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,7 +118,7 @@ end
       rendered = render(Diagram(diagram_format, specification), "png")
 
       @test rendered[1:length(PNG_HEADER)] == PNG_HEADER
-      @test rendered[(end - 8):end] == PNG_EOF
+      @test rendered[(end - length(PNG_EOF) + 1):end] == PNG_EOF
     end
 
     @testset "$(diagram_format) to SVG" for (diagram_format, specification) in


### PR DESCRIPTION
This PR

* Adds rendering support for PDF, where applicable.
* Add rendering 'support' for JPEG, where applicable. This is considered 'support' as, although all the necessary infrastructure/code is in place, actually rendering to JPEG is currently broken in the Kroki service. See 5d34345664ec9761200d03e9d60ee1d488f8fd18 for more details.
* Enables JPEG and plain text rendering of Structurizr diagrams.
* Exposes control over rendering diagrams to text. Previously these were hardcoded to render using Unicode characters, but this is now configurable through the `Kroki.TEXT_PLAIN_SHOW_MIME_TYPE` variable.
* Restructures how `LIMITED_DIAGRAM_SUPPORT`, `Base.show` and `Base.showable` interact.
* Includes some minor rendering related refactors and documentation updates.