### PR TITLE
Enable `strict` mode when building documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,7 @@ makedocs(
   modules = [Kroki],
   sitename = "Kroki.jl",
   pages = ["Home" => "index.md", "Examples" => "examples.md", "API" => "api.md"],
+  strict = true,
 )
 
 if get(ENV, "CI", nothing) == "true"


### PR DESCRIPTION
This ensures that when an example in the documentation fails to work, the documentation generation process fails. This decreases the odds of merging changes that break the documentation.