### PR TITLE
Restore full coverage

### DIFF
--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -284,8 +284,10 @@ Defaults to `$(TEXT_PLAIN_SHOW_MIME_TYPE[])`.
 const TEXT_PLAIN_SHOW_MIME_TYPE = Ref{MIME}(MIME"text/plain; charset=utf-8"())
 
 "All values that can be used to configure [`TEXT_PLAIN_SHOW_MIME_TYPE`](@ref)."
-const SUPPORTED_TEXT_PLAIN_SHOW_MIME_TYPES =
-  filter(mime -> startswith(string(mime), "text/plain"), keys(LIMITED_DIAGRAM_SUPPORT))
+const SUPPORTED_TEXT_PLAIN_SHOW_MIME_TYPES = Set([
+  mime for
+  mime in keys(Kroki.LIMITED_DIAGRAM_SUPPORT) if startswith(string(mime), "text/plain")
+])
 
 # The two-argument `Base.show` version is used to render the "text/plain" MIME
 # type. Those `Diagram` types that support text-based rendering, e.g. PlantUML,


### PR DESCRIPTION
Using a list comprehension to cover `SUPPORTED_TEXT_PLAIN_SHOW_MIME_TYPES` ensures it gets covered by tests.

It is not entirely clear why this line does not get measured as covered by tests when the `filter` approach is used. The expectation is that this has to do with the fact that the `filter` approach results in an iterator being assigned to `SUPPORTED_TEXT_PLAIN_SHOW_MIME_TYPES` resulting in a `Set`, whereas the list comprehension assigns a `Set`
constructed from a Vector`. This is pure speculation, trying to materialize the iterator approach first does not result in the line
being covered either.