### PR TITLE
Fix submodule docstrings

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -31,7 +31,7 @@ make it more straightforward to instantiate `Diagram`s.
 
 ```@autodocs
 Modules = [ Kroki.StringLiterals ]
-Order = [ :macro ]
+Order = [ :module, :macro ]
 ```
 
 ## Private

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -31,6 +31,7 @@ make it more straightforward to instantiate `Diagram`s.
 
 ```@autodocs
 Modules = [ Kroki.StringLiterals ]
+Order = [ :macro ]
 ```
 
 ## Private
@@ -65,4 +66,11 @@ Order = [ :constant ]
 
 ```@docs
 Kroki.Service.executeDockerCompose
+```
+
+### String Literals
+
+```@autodocs
+Modules = [ Kroki.StringLiterals ]
+Order = [ :function ]
 ```

--- a/src/kroki/exceptions.jl
+++ b/src/kroki/exceptions.jl
@@ -9,7 +9,10 @@ An `Exception` to be thrown when the `path` and `specification` keyword
 arguments to [`Diagram`](@ref) are not specified mutually exclusive.
 """
 struct DiagramPathOrSpecificationError <: Exception
+  "The `path` keyword argument passed to the [`Diagram`](@ref)."
   path::Maybe{AbstractString}
+
+  "The `specification` keyword argument passed to the [`Diagram`](@ref)."
   specification::Maybe{AbstractString}
 end
 
@@ -34,7 +37,13 @@ An `Exception` to be thrown when a [`Diagram`](@ref) representing an invalid
 specification is passed to [`render`](@ref Kroki.render).
 """
 struct InvalidDiagramSpecificationError <: Exception
+  """
+  The error message returned by the Kroki service causing the exception to be
+  thrown.
+  """
   error::String
+
+  "The [`Diagram`](@ref) that caused the error."
   cause::Diagram
 end
 
@@ -52,7 +61,13 @@ An `Exception` to be thrown when a [`Diagram`](@ref) is [`render`](@ref
 Kroki.render)ed to an unsupported or invalid output format.
 """
 struct InvalidOutputFormatError <: Exception
+  """
+  The error message returned by the Kroki service causing the exception to be
+  thrown.
+  """
   error::String
+
+  "The [`Diagram`](@ref) that caused the error."
   cause::Diagram
 end
 

--- a/src/kroki/exceptions.jl
+++ b/src/kroki/exceptions.jl
@@ -4,6 +4,9 @@ using HTTP.ExceptionRequest: StatusError
 
 using ..Kroki: Diagram, Kroki, Maybe
 
+using ..Documentation
+@setupDocstringMarkup()
+
 """
 An `Exception` to be thrown when the `path` and `specification` keyword
 arguments to [`Diagram`](@ref) are not specified mutually exclusive.

--- a/src/kroki/exceptions.jl
+++ b/src/kroki/exceptions.jl
@@ -1,3 +1,7 @@
+"""
+Defines all custom `Exceptions` that can be thrown by different parts of the
+package along with their corresponding `Base.showerror` overloads.
+"""
 module Exceptions
 
 using HTTP.ExceptionRequest: StatusError

--- a/src/kroki/string_literals.jl
+++ b/src/kroki/string_literals.jl
@@ -2,12 +2,14 @@ module StringLiterals
 
 using ..Kroki: Diagram, LIMITED_DIAGRAM_SUPPORT, getDiagramTypeMetadata
 
-# Helper function implementing string interpolation to be used in conjunction
-# with macros defining diagram specification string literals, as they do not
-# support string interpolation by default.
-#
-# Returns an array of elements, e.g. `Expr`essions, `Symbol`s, `String`s that
-# can be incorporated in the `args` of another `Expr`essions
+"""
+Helper function implementing string interpolation to be used in conjunction
+with macros defining diagram specification string literals, as they do not
+support string interpolation by default.
+
+Returns an array of elements, e.g. `Expr`essions, `Symbol`s, `String`s that can
+be incorporated in the `args` of another `Expr`ession.
+"""
 function interpolate(specification::AbstractString)
   # Based on the interpolation code from the Markdown stdlib and
   # https://riptutorial.com/julia-lang/example/22952/implementing-interpolation-in-a-string-macro
@@ -44,10 +46,12 @@ function interpolate(specification::AbstractString)
   esc.(components)
 end
 
-# When called at the start of an expression to interpolate, checks whether the
-# interpolation sign that triggered interpolation was escaped or not. This
-# takes into account multiple escaped escape characters in front of an
-# interpolation sign
+"""
+When called at the start of an expression to interpolate, checks whether the
+interpolation sign that triggered interpolation was escaped or not. This takes
+into account multiple escaped escape characters in front of an interpolation
+sign.
+"""
 function shouldInterpolate(stream::IO)
   interpolation_start = position(stream)
 

--- a/src/kroki/string_literals.jl
+++ b/src/kroki/string_literals.jl
@@ -1,3 +1,7 @@
+"""
+Defines string literals for all supported [`Diagram`](@ref) `type`s, making it
+more straightforward to write diagrams inline.
+"""
 module StringLiterals
 
 using ..Kroki: Diagram, LIMITED_DIAGRAM_SUPPORT, getDiagramTypeMetadata

--- a/src/kroki/string_literals.jl
+++ b/src/kroki/string_literals.jl
@@ -6,6 +6,9 @@ module StringLiterals
 
 using ..Kroki: Diagram, LIMITED_DIAGRAM_SUPPORT, getDiagramTypeMetadata
 
+using ..Documentation
+@setupDocstringMarkup()
+
 """
 Helper function implementing string interpolation to be used in conjunction
 with macros defining diagram specification string literals, as they do not


### PR DESCRIPTION
Not all submodules were using the standardized docstring markup definitions from `Kroki.documentation`, some were missing docstrings, or contained documentation that wasn't exposed yet.