### PR TITLE
Enable `strict` mode only in CI

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,7 @@ makedocs(
   modules = [Kroki],
   sitename = "Kroki.jl",
   pages = ["Home" => "index.md", "Examples" => "examples.md", "API" => "api.md"],
-  strict = true,
+  strict = haskey(ENV, "CI"),
 )
 
 if get(ENV, "CI", nothing) == "true"


### PR DESCRIPTION
Having this always enabled is cumbersome when writing documentation, it's only critical that documentation builds in CI.