### PR TITLE
DRY detection for running in CI for documentation generation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,16 @@
 using Documenter, Kroki
 
+const running_in_ci = get(ENV, "CI", nothing) == "true"
+
 makedocs(
   authors = "Joris Kraak",
   modules = [Kroki],
   sitename = "Kroki.jl",
   pages = ["Home" => "index.md", "Examples" => "examples.md", "API" => "api.md"],
-  strict = haskey(ENV, "CI"),
+  strict = running_in_ci,
 )
 
-if get(ENV, "CI", nothing) == "true"
+if running_in_ci
   deploydocs(
     devbranch = "development",
     devurl = "latest",


### PR DESCRIPTION
This check was effectively included twice. Better to push the most elaborate check into a variable and reuse that.