### PR TITLE
Add service `info` report

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,8 @@ Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
@@ -19,5 +21,6 @@ DocStringExtensions = "0.8, 0.9"
 # The wider compatibility range for `HTTP` ensures compatibility with
 # up-to-date versions of `Pluto`, etc.
 HTTP = "0.8, 0.9, 1"
+JSON = "0.21.3"
 Reexport = "1.2.2"
 julia = "1.6"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -64,7 +64,7 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.3"
 
 [[deps.Kroki]]
-deps = ["Base64", "CodecZlib", "DocStringExtensions", "HTTP", "Reexport"]
+deps = ["Base64", "CodecZlib", "DocStringExtensions", "HTTP", "JSON", "Markdown", "Reexport"]
 path = ".."
 uuid = "b3565e16-c1f2-4fe9-b4ab-221c88942068"
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -85,6 +85,10 @@ Markdown.parse(Kroki.renderDiagramSupportAsMarkdown(Kroki.LIMITED_DIAGRAM_SUPPOR
     output formats needs to be addressed within the Kroki service and then
     mirrored into this package.
 
+The [`Kroki.Service.info`](@ref) function can be used to obtain more detailed
+information about the versions of the tools used to support the different
+diagram types.
+
 ## Contents
 
 ```@contents

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -192,10 +192,8 @@ function renderDiagramSupportAsMarkdown(support::MIMEToDiagramTypeMap)
 
   diagram_types = sort(unique(Iterators.flatten(values(support))))
   diagram_types_with_support = map(diagram_types) do diagram_type
-    diagram_type_metadata = getDiagramTypeMetadata(diagram_type)
-
     return [
-      "[$(diagram_type_metadata.name)]($(diagram_type_metadata.url))",
+      toMarkdownLink(diagram_type),
       map(
         mime -> mime === MIME"image/svg+xml"() || diagram_type ∈ support[mime] ? "✅" : "",
         mime_types,
@@ -220,6 +218,11 @@ struct DiagramTypeMetadata
   "The URL to the website/documentation of the diagram type."
   url::String
 end
+
+# This is a common transformation across different documentation sections,
+# hence convenient to be available as helper functions
+toMarkdownLink(dtm::DiagramTypeMetadata) = "[$(dtm.name)]($(dtm.url))"
+toMarkdownLink(diagram_type::Symbol) = toMarkdownLink(getDiagramTypeMetadata(diagram_type))
 
 """
 An overview of metadata for the different [`Diagram`](@ref) `type`s that can be

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -18,9 +18,6 @@ include("./kroki/documentation.jl")
 using .Documentation
 @setupDocstringMarkup()
 
-include("./kroki/service.jl")
-using .Service: ENDPOINT
-
 export Diagram, render
 
 # Convenience short-hand to make further type definitions more straightforward
@@ -428,6 +425,9 @@ function Base.show(io::IO, diagram::Diagram)
     write(io, diagram.specification)
   end
 end
+
+include("./kroki/service.jl")
+using .Service: ENDPOINT
 
 include("./kroki/string_literals.jl")
 @reexport using .StringLiterals

--- a/src/kroki/exceptions.jl
+++ b/src/kroki/exceptions.jl
@@ -40,6 +40,26 @@ function Base.showerror(io::IO, error::DiagramPathOrSpecificationError)
 end
 
 """
+An `Exception` to be thrown when [`Kroki.Service.info`](@ref) cannot retrieve
+its information from the Kroki service configured through
+[`Kroki.Service.setEndpoint!`](@ref).
+"""
+struct InfoRetrievalError <: Exception
+  "The endpoint that was queried for information about a Kroki service."
+  endpoint::String
+end
+
+Base.showerror(io::IO, error::InfoRetrievalError) = print(
+  io,
+  """
+  The Kroki service at $(error.endpoint) could not be queried for information.
+
+  Please verify a Kroki service is active at this address, or reconfigure using
+  `Kroki.Service.setEndpoint!`.
+  """,
+)
+
+"""
 An `Exception` to be thrown when a [`Diagram`](@ref) representing an invalid
 specification is passed to [`render`](@ref Kroki.render).
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 SimpleMock = "a896ed2c-15a5-4479-b61d-a0e88e2a1d25"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/kroki/exceptions_test.jl
+++ b/test/kroki/exceptions_test.jl
@@ -5,6 +5,7 @@ using Test: @test, @test_throws, @testset
 using Kroki: Diagram, render
 using Kroki.Exceptions:
   DiagramPathOrSpecificationError,
+  InfoRetrievalError,
   InvalidDiagramSpecificationError,
   InvalidOutputFormatError,
   StatusError, # Imported from HTTP through Kroki
@@ -61,6 +62,19 @@ end
         @test occursin("* `specification`: '$(expected_specification)'", rendered_error)
       end
     end
+  end
+
+  @testset "`InfoRetrievalError`" begin
+    expected_endpoint = "http://test.endpoint"
+
+    rendered_error = sprint(showerror, InfoRetrievalError(expected_endpoint))
+
+    # Should state the cause of the error in a readable fashion
+    @test occursin("queried for information", rendered_error)
+
+    # Should contain the configured `ENDPOINT` and suggest to update it
+    @test occursin(expected_endpoint, rendered_error)
+    @test occursin("setEndpoint!", rendered_error)
   end
 
   @testset "`RenderError`" begin


### PR DESCRIPTION
The `Kroki.Service.info` report can be used to obtain a Markdown report on the diagramming tool versions supported by the configured Kroki service (and the version of that service). This should make it easier to debug rendering scenarios for different diagram types.