### PR TITLE
Pass objects as `replacements` for `Project.toml` update during release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -6,18 +6,20 @@
     [
       "@google/semantic-release-replace-plugin", {
         "replacements": [
-          "files": ["Project.toml"],
-          "from": "version = \"${lastRelease.version}\"",
-          "to": "version = \"${nextRelease.version}\"",
-          "results": [
-            {
-              "file": "Project.toml",
-              "hasChanged": true,
-              "numMatches": 1,
-              "numReplacements": 1
-            }
-          ],
-          "countMatches": true
+          {
+            "files": ["Project.toml"],
+            "from": "version = \"${lastRelease.version}\"",
+            "to": "version = \"${nextRelease.version}\"",
+            "results": [
+              {
+                "file": "Project.toml",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          }
         ]
       }
     ],


### PR DESCRIPTION
This configuration has been broken since its introduction in d25d7562be3b7b25df811b9c0e1dab10664ff770. This error wasn't triggered before due to the v0.1.0 release having run with the `dryRun` flag (8c98a29de1ecc8b155149d4224cc19fc8589494b), which skips this plugin.

See https://github.com/bauglir/Kroki.jl/runs/7515062574?check_suite_focus=true#step:3:888.