### PR TITLE
Detect version to replace during release using regular expression

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -8,7 +8,7 @@
         "replacements": [
           {
             "files": ["Project.toml"],
-            "from": "version = \"${lastRelease.version}\"",
+            "from": 'version = "\d+(\.\d+){2}"',
             "to": "version = \"${nextRelease.version}\"",
             "results": [
               {


### PR DESCRIPTION
In contrast to the `to` value for the [`@google/semantic-release-replace-plugin`](https://github.com/google/semantic-release-replace-plugin) configuration, the `from` configuration is not interpreted as a template. Hence, it is not possible to use the `lastRelease` variable made available by `semantic-release`.

Instead, the `to` configuration needs to be a regular expression compatible with `new Regexp(..., "gm")`.

See https://github.com/bauglir/Kroki.jl/runs/7515626072?check_suite_focus=true#step:3:910.