### PR TITLE
Detect theme changes based on associated fonts

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.7'
       - name: Install dependencies
         run: |
           julia --project=docs -e '

--- a/docs/architecture/workspace.dsl
+++ b/docs/architecture/workspace.dsl
@@ -76,17 +76,17 @@ workspace {
   }
 
   views {
-    container kroki_jl {
+    container kroki_jl PackageContainers {
       include *
       autoLayout lr
     }
 
-    component library {
+    component library PackageComponents {
       include *
       autoLayout bt
     }
 
-    container kroki_service {
+    container kroki_service ServiceContainers {
       include *
       autoLayout tb
     }

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -182,7 +182,7 @@ rendered from the set defined in the file.
 structurizr_diagram = Diagram(
   :structurizr;
   path = joinpath(@__DIR__, "..", "architecture", "workspace.dsl"),
-  options = Dict("view-key" => "KrokiService-Container")
+  options = Dict("view-key" => "ServiceContainers")
 )
 ```
 
@@ -218,7 +218,7 @@ end
 DocumenterSvg(
   render(
     structurizr_diagram, "svg";
-    options = Dict("view-key" => "Krokijl-Krokijl-Component")
+    options = Dict("view-key" => "PackageComponents")
   )
 )
 ```

--- a/test/kroki/rendering_test.jl
+++ b/test/kroki/rendering_test.jl
@@ -89,23 +89,25 @@ end
     end
 
     @testset "takes `options` into account" begin
-      expected_theme_name = "materia"
-      options = Dict{String, String}("theme" => expected_theme_name)
+      options = Dict{String, String}("theme" => "materia")
       diagram = Diagram(:plantuml, "A -> B: C"; options)
 
+      # The most straightforward way to differentiate between the themes used
+      # for testing is by checking the associated fonts. The "Materia" theme
+      # relies on "Verdana", whereas the "Sketchy" theme relies on the
+      # handwritten look of "Segoe Print"
       @testset "defaults to `Diagram` options" begin
         rendered = String(render(diagram, "svg"))
 
-        @test occursin("!theme $(expected_theme_name)", rendered)
+        @test occursin("Verdana", rendered)
       end
 
       @testset "allows definition at render-time" begin
-        expected_overridden_theme = "sketchy"
         rendered = String(
-          render(diagram, "svg"; options = Dict("theme" => expected_overridden_theme)),
+          render(diagram, "svg"; options = Dict{String, String}("theme" => "sketchy")),
         )
 
-        @test occursin("!theme $(expected_overridden_theme)", rendered)
+        @test occursin("Segoe Print", rendered)
       end
     end
   end


### PR DESCRIPTION
For previous versions of the Kroki service, the full source of the diagram was included in rendered results which made it possible to directly detect the theme. This is no longer the case[^1], making it necessary to detect the effect of a theme. The most straightforward way to do this is by detecting fonts referenced in the rendered results.

[^1]: https://github.com/bauglir/Kroki.jl/actions/runs/8038302157/job/21954056804?pr=49#step:5:126