### PR TITLE
Fix formatting and TikZ/PGF support documentation

### DIFF
--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -255,7 +255,7 @@ DIAGRAM_TYPE_METADATA = Dict{Symbol, DiagramTypeMetadata}(
     DiagramTypeMetadata("Svgbob", "https://ivanceras.github.io/content/Svgbob.html"),
   :symbolator =>
     DiagramTypeMetadata("Symbolator", "https://github.com/kevinpt/symbolator"),
-  :tikz => DiagramTypeMetadata("Symbolator", "https://github.com/pgf-tikz/pgf"),
+  :tikz => DiagramTypeMetadata("TikZ/PGF", "https://github.com/pgf-tikz/pgf"),
   :umlet => DiagramTypeMetadata("UMLet", "https://github.com/umlet/umlet"),
   :vega => DiagramTypeMetadata("Vega", "https://vega.github.io/vega"),
   :vegalite => DiagramTypeMetadata("Vega-Lite", "https://vega.github.io/vega-lite"),

--- a/src/Kroki.jl
+++ b/src/Kroki.jl
@@ -253,7 +253,8 @@ DIAGRAM_TYPE_METADATA = Dict{Symbol, DiagramTypeMetadata}(
   :structurizr => DiagramTypeMetadata("Structurizr", "https://structurizr.com"),
   :svgbob =>
     DiagramTypeMetadata("Svgbob", "https://ivanceras.github.io/content/Svgbob.html"),
-  :symbolator => DiagramTypeMetadata("Symbolator", "https://github.com/kevinpt/symbolator"),
+  :symbolator =>
+    DiagramTypeMetadata("Symbolator", "https://github.com/kevinpt/symbolator"),
   :tikz => DiagramTypeMetadata("Symbolator", "https://github.com/pgf-tikz/pgf"),
   :umlet => DiagramTypeMetadata("UMLet", "https://github.com/umlet/umlet"),
   :vega => DiagramTypeMetadata("Vega", "https://vega.github.io/vega"),
@@ -334,17 +335,8 @@ const LIMITED_DIAGRAM_SUPPORT = MIMEToDiagramTypeMap(
     :vegalite,
     :wireviz,
   ),
-  MIME"image/svg+xml"() => (
-    :bpmn,
-    :bytefield,
-    :d2,
-    :dbml,
-    :excalidraw,
-    :nomnoml,
-    :pikchr,
-    :svgbob,
-    :wavedrom
-  ),
+  MIME"image/svg+xml"() =>
+    (:bpmn, :bytefield, :d2, :dbml, :excalidraw, :nomnoml, :pikchr, :svgbob, :wavedrom),
   MIME"text/plain"() => (:c4plantuml, :plantuml, :structurizr),
   MIME"text/plain; charset=utf-8"() => (:c4plantuml, :plantuml, :structurizr),
 )


### PR DESCRIPTION
These are both minor fixes for #56. Code formatting was incorrect, but the corresponding workflows was not marked as required causing the PR to merge when it shouldn't have and the TikZ/PGF metadata was incorrectly marked as "Symbolator" causing the latter to show up in [the support matrix](https://bauglir.github.io/Kroki.jl/latest/#diagram-support) twice.

![image](https://github.com/bauglir/Kroki.jl/assets/47904/19dd35f9-c705-48b2-acfa-78cf6378f633)