### PR TITLE
Fix link to Structurizr DSL in documentation

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -229,7 +229,7 @@ DocumenterSvg(
     from the [Structurizr (Lite) software](https://structurizr.com/help/lite),
     or they can be specified as [the second argument to 'view definitions'
     using the Structurizr
-    DSL](https://github.com/structurizr/dsl/blob/master/docs/language-reference.md#views).
+    DSL](https://docs.structurizr.com/dsl/language#views).
 
 ## Rendering to a specific format
 


### PR DESCRIPTION
[The `structurizr/dsl` repository](https://github.com/structurizr/dsl) has been archived. The Structurizr website is now the canonical source for documentation.