### PR TITLE
Improve release workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4
+        id: semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -25,5 +26,6 @@ jobs:
             @ethima/semantic-release-configuration
       - name: Notify JuliaRegistrator of new release
         uses: peter-evans/commit-comment@v3
+        if: steps.semantic-release.outputs.new_release_published == 'true'
         with:
           body: '@JuliaRegistrator register branch=main'

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,4 +28,4 @@ jobs:
         uses: peter-evans/commit-comment@v3
         if: steps.semantic-release.outputs.new_release_published == 'true'
         with:
-          body: '@JuliaRegistrator register branch=main'
+          body: '@JuliaRegistrator register branch=${{ steps.semantic-release.outputs.new_release_git_tag }}'


### PR DESCRIPTION
Some minor improvements to the release workflow. Previously it was possible to trigger `JuliaRegistrator` for workflow runs that did not end up resulting in a release (which wasn't a problem due to the workflow followed by this project) and the branch passed to `JuliaRegistrator` was not as strict as it could be which could cause potential issues in rare cases.