### PR TITLE
Enable showable overrides per diagram type

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -13,7 +13,9 @@ Diagram(::Symbol, ::AbstractString)
 Diagram(::Symbol; ::Union{Nothing,AbstractString}, ::Union{Nothing,AbstractString})
 SUPPORTED_TEXT_PLAIN_SHOW_MIME_TYPES
 TEXT_PLAIN_SHOW_MIME_TYPE
+overrideShowable
 render
+resetShowableOverrides
 ```
 
 ### Service Management
@@ -41,8 +43,10 @@ DiagramTypeMetadata
 DIAGRAM_TYPE_METADATA
 LIMITED_DIAGRAM_SUPPORT
 MIME_TO_RENDER_ARGUMENT_MAP
+SHOWABLE_OVERRIDES
 UriSafeBase64Payload
 getDiagramTypeMetadata
+normalizeDiagramType
 ```
 
 ### Documentation

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -269,15 +269,54 @@ using `write`.
 write("mermaid_diagram.png", mermaid_diagram_as_png)
 ```
 
-![Mermaid diagram as PNG example](mermaid_diagram.png)
-
-Note the difference in file size and fonts when rendering to SVG.
+Note the difference in file size when rendering to SVG.
 
 ```@example diagrams
 write("mermaid_diagram.svg", render(mermaid_diagram, "svg"))
 ```
 
-![Mermaid diagram as SVG example](mermaid_diagram.svg)
+### Overriding `Base.show` behavior
+
+In some cases the output format that is used may affect how the final diagram
+renders. Although it is always possible to explicitly fall back to calling
+`render` in these cases, this may be cumbersome when writing documentation,
+etc. and having to explicitly do that for every diagram of a specific type. As
+an alternative, it is possible to instruct `Kroki` to ignore certain output
+formats when rendering a specific diagram type using `Base.show`.
+
+For instance, by default (in most cases) a Mermaid diagram will be rendered as
+an SVG. Due to the way these diagrams are rendered by Kroki this may result in
+text getting cut off, see
+[yuzutech/kroki#1345](https://github.com/yuzutech/kroki/issues/1345) for
+details.
+
+```@example diagrams
+mermaid_diagram
+```
+
+!!! tip "Inspecting the output format of an image"
+
+    The most straightforward way of inspecting the output format is to open the
+    image in a new tab in your browser and checking its extension, e.g. by
+    right clicking on it and selecting _Open image in new tab_ in Chrome or a
+    similar browser. Alternatively the type of the rendered image can be seen
+    by inspecting the source of this page.
+
+Using [`Kroki.overrideShowable`](@ref), `Kroki` can be instructed to not render
+to SVG and pick the next most suitable output format with a fallback of
+rendering the diagram to text if none are available.
+
+```@example diagrams
+Kroki.overrideShowable(MIME"image/svg+xml"(), :mermaid, false)
+```
+
+For Mermaid diagrams in the context of `Documenter` this means rendering the
+diagram as a PNG. When rendering to PNG the previously mentioned font issues do
+not arise.
+
+```@example diagrams
+mermaid_diagram
+```
 
 ## Controlling text rendering
 

--- a/test/kroki/rendering_test.jl
+++ b/test/kroki/rendering_test.jl
@@ -113,6 +113,10 @@ end
   end
 
   @testset "`Base.show`" begin
+    pdf_mime_type = MIME"application/pdf"()
+    png_mime_type = MIME"image/png"()
+    svg_mime_type = MIME"image/svg+xml"()
+
     # Svgbob diagrams only support SVG output. Any other formats should throw
     # `InvalidOutputFormatError`s when called directly.
     #
@@ -121,23 +125,20 @@ end
     # should be overridden to indicate the diagram cannot be rendered in the
     # specified MIME type
     svgbob_diagram = Diagram(:svgbob, "-->[_...__... ]")
-    @test_throws(
-      InvalidOutputFormatError,
-      show(IOBuffer(), MIME"application/pdf"(), svgbob_diagram)
-    )
-    @test !showable("application/pdf", svgbob_diagram)
-    @test_throws(InvalidOutputFormatError, sprint(show, MIME"image/png"(), svgbob_diagram))
-    @test !showable(MIME"image/png"(), svgbob_diagram)
+    @test_throws(InvalidOutputFormatError, show(IOBuffer(), pdf_mime_type, svgbob_diagram))
+    @test !showable(pdf_mime_type, svgbob_diagram)
+    @test_throws(InvalidOutputFormatError, sprint(show, png_mime_type, svgbob_diagram))
+    @test !showable(png_mime_type, svgbob_diagram)
     @test_throws(
       InvalidOutputFormatError,
       show(IOBuffer(), MIME"image/jpeg"(), svgbob_diagram)
     )
     @test !showable("image/jpeg", svgbob_diagram)
-    testShowMethodRenders(svgbob_diagram, MIME"image/svg+xml"(), "svg")
+    testShowMethodRenders(svgbob_diagram, svg_mime_type, "svg")
     @test !showable("non-existent/mime-type", svgbob_diagram)
 
     plantuml_diagram = Diagram(:PlantUML, "A -> B: C")
-    testShowMethodRenders(plantuml_diagram, MIME"image/png"(), "png")
+    testShowMethodRenders(plantuml_diagram, png_mime_type, "png")
     # PlantUML diagrams support SVG, but are not part of the
     # `LIMITED_DIAGRAM_SUPPORT` as they support more output formats.
     #
@@ -145,13 +146,15 @@ end
     # is necessary to make sure a `showable` method is available to indicate
     # SVG is always supported to those enviroments that need to query that
     # information
-    @test showable(MIME"image/svg+xml"(), plantuml_diagram)
-    testShowMethodRenders(plantuml_diagram, MIME"image/svg+xml"(), "svg")
+    @test showable(svg_mime_type, plantuml_diagram)
+    testShowMethodRenders(plantuml_diagram, svg_mime_type, "svg")
 
     @testset "`text/plain`" begin
+      plain_text_mime_type = MIME"text/plain"()
+
       @testset "without ASCII/Unicode rendering support" begin
         # These diagram types should simply display their `specification`
-        @test sprint(show, MIME"text/plain"(), svgbob_diagram) ==
+        @test sprint(show, plain_text_mime_type, svgbob_diagram) ==
               svgbob_diagram.specification
       end
 
@@ -166,15 +169,15 @@ end
         Kroki.TEXT_PLAIN_SHOW_MIME_TYPE[] = MIME"text/plain; charset=utf-8"()
         testShowMethodRenders(plantuml_diagram, MIME"text/plain"(), "utxt")
 
-        Kroki.TEXT_PLAIN_SHOW_MIME_TYPE[] = MIME"text/plain"()
+        Kroki.TEXT_PLAIN_SHOW_MIME_TYPE[] = plain_text_mime_type
         testShowMethodRenders(plantuml_diagram, MIME"text/plain"(), "txt")
 
         @testset "generates an error if an invalid `text/plain` MIME type is configured" begin
-          Kroki.TEXT_PLAIN_SHOW_MIME_TYPE[] = MIME"image/png"()
+          Kroki.TEXT_PLAIN_SHOW_MIME_TYPE[] = png_mime_type
 
           @test_throws(
             UnsupportedMIMETypeError,
-            show(IOBuffer(), MIME"text/plain"(), plantuml_diagram)
+            show(IOBuffer(), plain_text_mime_type, plantuml_diagram)
           )
         end
 


### PR DESCRIPTION
`Kroki` tries to select the most suitable output format to render a diagram in using Julia's `Base.show` and `AbstractDisplay` capabilities. Situations may occur where the "best" output format that gets determined is not actually the "best" output format.

This new functionality enables control over which output formats will be used by `Base.show`, in particular allowing specific output formats to be disabled. This approach prevents the need for having to explicitly construct a `Diagram` and `render`ing it and will also work when defining diagrams using the string literals.

This is technically not a breaking change. However, given that the overall API of this package has proven stable over a long period of time this addition is a good point in time to move to v1.y.z.

Closes https://github.com/bauglir/Kroki.jl/issues/51.