### PR TITLE
ci(deps): upgrade semantic release tooling

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v6
         id: semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          semantic_version: 23.0.2
+          semantic_version: 25.0.3
           extends: |
             @ethima/semantic-release-configuration
           extra_plugins: |


### PR DESCRIPTION
The previous version of the tooling cannot correctly pull in the shared configuration anymore. Upgrading the tooling addresses the issue. This is likely a CommonJS versus ESM issue.